### PR TITLE
Refactored Itinerary List

### DIFF
--- a/api/itineraries.json
+++ b/api/itineraries.json
@@ -71,6 +71,36 @@
       "eatery": "2",
       "attraction": "2",
       "id": 12
+    },
+    {
+      "park": "afam",
+      "eatery": "1",
+      "attraction": "1",
+      "id": 13
+    },
+    {
+      "park": "Augusta Canal",
+      "eatery": "1",
+      "attraction": "3",
+      "id": 14
+    },
+    {
+      "park": "African American Civil War Memorial",
+      "eatery": "Big Bob Gibson Bar-B-Que",
+      "attraction": "6",
+      "id": 15
+    },
+    {
+      "park": "Dry Tortugas",
+      "eatery": "Buckhorn Exchange",
+      "attraction": "Snake World",
+      "id": 16
+    },
+    {
+      "park": "Fort Stanwix",
+      "eatery": "St. Elmo Steak House",
+      "attraction": "World’s Largest ‘Gone With the Wind’ Collection",
+      "id": 17
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -34,8 +34,6 @@
 
     <footer class="footerContainer"></footer>
 
-    <footer class="footerContainer"></footer>
-
     <script type="module" src="./scripts/main.js"></script>
   </body>
 </html>

--- a/scripts/itineraries/ItineraryDataProvider.js
+++ b/scripts/itineraries/ItineraryDataProvider.js
@@ -15,7 +15,6 @@ export const getItineraries = () => {
         })
 }
 
-
 export const saveItinerary = (newItinerary) => {
     fetch("http://localhost:3000/itineraries", {
         method: "POST",

--- a/scripts/itineraries/ItineraryList.js
+++ b/scripts/itineraries/ItineraryList.js
@@ -1,5 +1,8 @@
 import { Itinerary } from './Itinerary.js'
 import { useItineraries } from './ItineraryDataProvider.js'
+import { useParks } from '../parks/ParkDataProvider.js';
+import { useEateries } from '../eateries/EateryDataProvider.js';
+import { useAttractions } from '../attractions/AttractionDataProvider.js';
 
 const contentTarget = document.querySelector(".itinerariesContainer");
 

--- a/scripts/parks/ParkSelector.js
+++ b/scripts/parks/ParkSelector.js
@@ -11,7 +11,7 @@ export const ParkSelector = () => {
         <select id="parkSelect">
             <option value="0">Pick a Park</option>
             ${parksCollection.map(singlePark => {
-        return `<option value="${singlePark.id}">${singlePark.name}</option>`
+        return `<option value="${singlePark.parkCode}">${singlePark.name}</option>`
     })}
         </select>
     `

--- a/scripts/preview/ItineraryPreview.js
+++ b/scripts/preview/ItineraryPreview.js
@@ -38,7 +38,7 @@ const verifyUserSelection = () => {
 eventHub.addEventListener('parkChosen', customEvent => {
   const parksArray = useParks()
   const foundPark = parksArray.find(parkObj => {
-    return parkObj.id === (customEvent.detail.chosenPark)
+    return parkObj.parkCode === (customEvent.detail.chosenPark)
   })
   parkContentTarget.innerHTML = Park(foundPark)
   userChoices.parkChosen = true
@@ -72,12 +72,33 @@ contentTarget.addEventListener("click", clickEvent => {
     const parkSelected = document.querySelector("#parkSelect").value
     const eaterySelected = document.querySelector("#eaterySelect").value
     const attractionSelected = document.querySelector("#attractionSelect").value
+    // Find the corresonding park object an grab its name 
+    const parksList = useParks()
+    const locatedPark = parksList.find(parkObject => {
+      return parkObject.parkCode === parkSelected
+    })
+     // Find the corresonding eatery object an grab its name 
+     const eateriesList = useEateries()
+     const locatedEatery = eateriesList.find(eateryObject => {
+       return eateryObject.id === parseInt(eaterySelected)
+     })
+     // Find the corresonding attraction object an grab its name 
+     const attractionsList = useAttractions()
+     const locatedAttraction = attractionsList.find(attractionObject => {
+       return attractionObject.id === parseInt(attractionSelected)
+     })
 
+
+
+
+
+    // Store the data for the saved itinerary display and call function to render it 
     const newItinerary = {
-      park: parkSelected,
-      eatery: eaterySelected,
-      attraction: attractionSelected
+      park: locatedPark.name,
+      eatery: locatedEatery.businessName,
+      attraction: locatedAttraction.name
     }
   saveItinerary(newItinerary)
   }
 })
+


### PR DESCRIPTION
#Changes 
  *Refactored the itinerary list to reflect park, attraction, and eatery names in the UI

#Testing 
  *Serve the application to localhost
  *Select a park, an eatery, and an attraction in the dropdowns at the top of the page
  *Click the Save button at the bottom of the page once all three selections have been made. 
  *Refresh the page, and scroll to the bottom to view the new itinerary. 
  *Verify that the corresponding names for the selected park, eatery, and attraction appear in the new itinerary card. 