### PR TITLE
Added Refresh Functionality to the Itinerary List 

### DIFF
--- a/api/itineraries.json
+++ b/api/itineraries.json
@@ -7,22 +7,34 @@
       "attraction": "Attraction Name"
     },
     {
-      "park": "Cape Cod",
-      "eatery": "Buckhorn Exchange",
-      "attraction": "White House Replica",
+      "park": "African American Civil War Memorial",
+      "eatery": "Big Bob Gibson Bar-B-Que",
+      "attraction": "Giant Tattoo Needle",
       "id": 2
     },
     {
-      "park": "Augusta Canal",
+      "park": "African American Civil War Memorial",
       "eatery": "Big Bob Gibson Bar-B-Que",
-      "attraction": "Giant Tattoo Needle",
+      "attraction": "Snake World",
       "id": 3
     },
     {
       "park": "Augusta Canal",
-      "eatery": "Big Bob Gibson Bar-B-Que",
-      "attraction": "Giant Tattoo Needle",
+      "eatery": "Club Paris",
+      "attraction": "Snake World",
       "id": 4
+    },
+    {
+      "park": "Augusta Canal",
+      "eatery": "Big Bob Gibson Bar-B-Que",
+      "attraction": "Elvis Memorial Chapel",
+      "id": 5
+    },
+    {
+      "park": "African American Civil War Memorial",
+      "eatery": "Club Paris",
+      "attraction": "Avery’s Beverages",
+      "id": 6
     }
   ]
 }

--- a/scripts/itineraries/ItineraryList.js
+++ b/scripts/itineraries/ItineraryList.js
@@ -1,10 +1,8 @@
 import { Itinerary } from './Itinerary.js'
 import { useItineraries } from './ItineraryDataProvider.js'
-import { useParks } from '../parks/ParkDataProvider.js';
-import { useEateries } from '../eateries/EateryDataProvider.js';
-import { useAttractions } from '../attractions/AttractionDataProvider.js';
 
-const contentTarget = document.querySelector(".itinerariesContainer");
+let contentTarget = document.querySelector(".itinerariesContainer");
+const eventHub = document.querySelector(".container")
 
 export const renderItinerary = () => {
     const itineraryEntries = useItineraries();
@@ -13,3 +11,10 @@ export const renderItinerary = () => {
         contentTarget.innerHTML += newItinerary
     }
 }
+
+
+eventHub.addEventListener("saveItinerary", customEvent => {
+
+    contentTarget.innerHTML = ""
+    renderItinerary()
+})


### PR DESCRIPTION
#Changes
*Added functionality to automatically refresh the itinerary list when save button is clicked

#Testing
*Serve the application to a localhost server
*Use the park, eatery, and attractions dropdowns to create an itinerary. 
*Click the "Save this adventure" button. 
*Review the saved itinerary list to ensure that the new itinerary was saved automatically without having to refresh the page. 